### PR TITLE
Refactorizacion de animeController para separar las validaciones en u…

### DIFF
--- a/app/Http/Requests/anime/FindByIdAnimeRequest.php
+++ b/app/Http/Requests/anime/FindByIdAnimeRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\anime;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FindByIdAnimeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'id' => 'required|min:1|max:999999|exists:animes,id',
+        ];
+    }
+}

--- a/app/Http/Requests/anime/StoreAnimeRequest.php
+++ b/app/Http/Requests/anime/StoreAnimeRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\anime;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreAnimeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $validation = [
+            'title'           => 'required|string|max:255|unique:animes,title',
+            'description'     => 'required|string|max:255',
+            'cover_image'     => 'required|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
+            'thumbnail_image' => 'required|image|mimes:jpeg,png,jpg,gif,svg|max:2048'
+        ];
+
+        if($this->isMethod('put')) {
+            $validation['id']    = 'required|int|min:1|max:999999|exists:animes,id';
+            $validation['title'] = $validation['title'].",{$this->id}";
+        }
+
+        return $validation;
+    }
+}

--- a/resources/views/admin/anime/edit.blade.php
+++ b/resources/views/admin/anime/edit.blade.php
@@ -2,9 +2,10 @@
 
 @section('content')
     <h1>Editar Anime</h1>
-    <form action="{{ route('admin.anime.update', $anime) }}" method="POST" enctype="multipart/form-data">
+    <form action="{{ route('admin.anime.update', ['id' => $anime->id]) }}" method="POST" enctype="multipart/form-data">
         @csrf
         @method('PUT')
+        
         <div class="form-group mt-2">
             <label for="title">Title</label>
             <input type="text" name="title" id="title" class="form-control" value="{{ old('title', $anime->title) }}">

--- a/resources/views/admin/anime/index.blade.php
+++ b/resources/views/admin/anime/index.blade.php
@@ -26,10 +26,13 @@
                                 <td>
                                     <a class="btn btn-sm btn-info" href="{{route('episodes.index', $anime->id)}}">Ver Episodios</a>
 
-                                    <a href="{{ route('admin.anime.edit', $anime) }}" class="btn btn-sm btn-warning">Editar</a>
-                                    <form action="{{ route('admin.anime.destroy', $anime) }}" method="POST" class="d-inline">
+                                    <a href="{{ route('admin.anime.edit', ['id' => $anime->id]) }}" class="btn btn-sm btn-warning">Editar</a>
+
+                                    <form action="{{ route('admin.anime.destroy', $anime->id) }}" method="POST" class="d-inline">
                                         @csrf
                                         @method('DELETE')
+                                        <input type="hidden" name="id" value="{{ $anime->id }}">
+
                                         <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('¿Estás seguro de eliminar este anime?')">Eliminar</button>
                                     </form>
                                 </td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,10 +24,10 @@ Route::middleware('is_admin')->prefix('admin')->group(function () {
     // Rutas de animes aquí...
     Route::get('/anime', [App\Http\Controllers\Admin\AnimeController::class, 'index'])->name('admin.anime.index');
     Route::get('/anime/create', [App\Http\Controllers\Admin\AnimeController::class, 'create'])->name('admin.anime.create');
-    Route::get('/anime/{anime}/edit', [App\Http\Controllers\Admin\AnimeController::class, 'edit'])->name('admin.anime.edit');
-    Route::get('/anime/{anime}/destroy', [App\Http\Controllers\Admin\AnimeController::class, 'destroy'])->name('admin.anime.destroy');
+    Route::get('/anime/{id}/edit', [App\Http\Controllers\Admin\AnimeController::class, 'edit'])->name('admin.anime.edit');
+    Route::delete('/anime/destroy', [App\Http\Controllers\Admin\AnimeController::class, 'destroy'])->name('admin.anime.destroy');
     Route::post('/anime/store', [App\Http\Controllers\Admin\AnimeController::class, 'store'])->name('admin.anime.store');
-    Route::put('/anime/{anime}/update', [App\Http\Controllers\Admin\AnimeController::class, 'update'])->name('admin.anime.update');
+    Route::put('/anime/update', [App\Http\Controllers\Admin\AnimeController::class, 'update'])->name('admin.anime.update');
 
     Route::prefix('anime/{anime}')->group(function () {
         Route::resource('episodes', App\Http\Controllers\Admin\EpisodeController::class);


### PR DESCRIPTION
En lugar de tener todas las validaciones en el controlador animeController, separe las validaciones en un archivo de solicitud llamado StoreAnimeRequest. Esto ayudara a mantener el código más organizado y se facilitara la reutilización de las validaciones en otros controladores.